### PR TITLE
Clear data from article that was previously on the page, when user selects a new topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Giphy_API
 
 How to create a link with JavaScript: https://www.geeksforgeeks.org/how-to-create-a-link-in-javascript/
+
+How to add attributes, such as an id, to an element in the DOM, using JavaScript: https://www.delftstack.com/howto/javascript/add-id-to-element-using-javascript/
+
+How to remove an element from the DOM once it is no longer needed using the removeChild() method: https://www.w3schools.com/jsref/met_node_removechild.asp
+
+How to remove an element from the DOM using the remove() method once it is no longer needed: https://www.w3schools.com/jsref/met_element_remove.asp
+
+How to get the value of a select field from an HTML form, using JavaScript:
+
+- https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_select_value
+
+- https://www.w3schools.com/jsref/prop_select_value.asp
+
+- https://ricardometring.com/getting-the-value-of-a-select-in-javascript
+
+- https://stackoverflow.com/questions/19329978/change-selects-option-and-trigger-events-with-javascript
+
+The last link mentioned also shows how to listen to JavaScript events.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Giphy_API
+
+How to create a link with JavaScript: https://www.geeksforgeeks.org/how-to-create-a-link-in-javascript/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 How to create a link with JavaScript: https://www.geeksforgeeks.org/how-to-create-a-link-in-javascript/
 
-How to add attributes, such as an id, to an element in the DOM, using JavaScript: https://www.delftstack.com/howto/javascript/add-id-to-element-using-javascript/
+How to add attributes, such as an id, to an element in the DOM, using JavaScript:
+
+- https://www.delftstack.com/howto/javascript/add-id-to-element-using-javascript/
+
+- https://www.javascripttutorial.net/dom/attributes/set-the-value-of-an-attribute/
+
+How to Use the Fetch API (Video Tutorial): https://www.youtube.com/watch?v=cuEtnrL9-H0&list=PLZlA0Gpn_vH9k5ju1yq9qCDqvtuTVgTr6&index=15
 
 How to remove an element from the DOM once it is no longer needed using the removeChild() method: https://www.w3schools.com/jsref/met_node_removechild.asp
 

--- a/script.js
+++ b/script.js
@@ -78,6 +78,13 @@ function populateWebPageWithServerData(jsonData) {
 	*/
 
 	document.body.appendChild(img);
+	populateWebPageWithArticleTxt(contentSections);
+	//console.log(resource);
+	createLinkToArticleSource(infoLinkURL);
+	
+}
+
+function populateWebPageWithArticleTxt(contentSections) {
 	numOfContentDivs = contentSections.length;
 
 	for (let i = 0; i < numOfContentDivs; i++) {			
@@ -96,13 +103,14 @@ function populateWebPageWithServerData(jsonData) {
 		}
 		document.body.appendChild(div);
 	}
-	//console.log(resource);
+}
 
+function createLinkToArticleSource(linkURL) {
 	let a = document.createElement('a'); 
 	let link = document.createTextNode("Source");
 	a.appendChild(link);
 	a.title = "Link to the source of this content."; 
-	a.href = infoLinkURL;
+	a.href = linkURL;
 	a.target = "_blank";
 	a.id = "sourceLink";
 	/* The code above is the same as the following: 
@@ -113,11 +121,6 @@ function populateWebPageWithServerData(jsonData) {
 	*/
 	document.body.appendChild(a); 
 }
-
-function createLinkToArticleSource(linkURL) {
-
-}
-
 
 function clearWebPageOfOldData() {
 	let h1$ = document.getElementById('contentTitle');
@@ -134,15 +137,6 @@ function clearWebPageOfOldData() {
 	
 	a$.remove();
 }
-
-/*
-function clearWebPageOfOldData() {
-	document.body.removeChild(h1);
-	document.body.removeChild(img);
-	document.body.removeChild(div); 
-	document.body.removeChild(a);
-}
-*/
 
 function loadPageContent(keyword) {
 	fetch(`https://health.gov/myhealthfinder/api/v3/topicsearch.json?keyword=${keyword}`)

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-let keyword = 'physical+activity'; //flu, preeclampsia, osteoporosis, tuberculosis, skin, weight, bone+density, weight, checkups, physical+activity, heart, lungs, cancer, diabetes, vaccines 
+let keyword = 'physical+activity'; 
 
 function turnKeywordIntoHeaderTxt(keyword) {
 	wordLength = keyword.length;
@@ -48,6 +48,8 @@ function createTitleFromMultipleWords(wordsArr) {
 	return wordsUnitedIntoTitle;
 }
 
+let numOfContentDivs;
+
 function populateWebPageWithServerData(jsonData) {
 	const resource = jsonData.Result.Resources.Resource[0];
 	let infoLinkURL = resource.AccessibleVersion;
@@ -56,15 +58,35 @@ function populateWebPageWithServerData(jsonData) {
 	let contentSections = resource.Sections.section;
 	let h1 = document.createElement('h1');
 	h1.innerText = title;
+	h1.id = "contentTitle";
 	document.body.appendChild(h1);
 
 	let img = document.createElement("img");
-	img.setAttribute("src", imgURL);
-	img.setAttribute("width", 400)
-	document.body.appendChild(img);
 
-	for (let i = 0; i < contentSections.length; i++) {			
+	img.src = imgURL;
+	/* 
+		The line of code above is the equivalent of the following line of code:
+		img.setAttribute("src", imgURL);
+	*/
+
+	img.id = "image";
+
+	img.style.width = "25rem";
+	/* 
+		The line of code above is similar to the following; and produces almost the same effect:
+		img.setAttribute("width", 400);
+	*/
+
+	document.body.appendChild(img);
+	numOfContentDivs = contentSections.length;
+
+	for (let i = 0; i < numOfContentDivs; i++) {			
 		let div = document.createElement('div');
+		div.id = `contentDiv${i}`;
+		/* The code above is the same as the following: 
+		div.setAttribute('id', `contentDiv${i}`);
+		*/
+
 		if (contentSections[i].Title !== null) {
 			div.innerHTML = `<h2> ${contentSections[i].Title} </h2>`;
 			div.innerHTML += contentSections[i].Content;
@@ -74,27 +96,53 @@ function populateWebPageWithServerData(jsonData) {
 		}
 		document.body.appendChild(div);
 	}
-	console.log(resource);
+	//console.log(resource);
 
 	let a = document.createElement('a'); 
 	let link = document.createTextNode("Source");
-	a.appendChild(link); 
+	a.appendChild(link);
 	a.title = "Link to the source of this content."; 
 	a.href = infoLinkURL;
-	a.target = '_blank';
-	document.body.appendChild(a); 
-	/*let a = document.createElement('a');
-	a.textContent = 'Source';
-	a.setAttribute(href, infoLinkURL);
-	document.body.insertBefore(div, a);
-		//div1.appendChild(h2);
-	/*
-	var gifTitle = jsonData.data.title;
-	var caption = document.createElement("h3");
-	caption.innerHTML = gifTitle;
-	document.body.appendChild(caption);
+	a.target = "_blank";
+	a.id = "sourceLink";
+	/* The code above is the same as the following: 
+	a.setAttribute('title', 'Link to the source of this content.');
+	a.setAttribute('href', infoLinkURL);
+	a.setAttribute('target', '_blank')
+	a.setAttribute('id', 'sourceLink');
 	*/
+	document.body.appendChild(a); 
 }
+
+function createLinkToArticleSource(linkURL) {
+
+}
+
+
+function clearWebPageOfOldData() {
+	let h1$ = document.getElementById('contentTitle');
+	let img$ = document.getElementById('image');
+	let a$ = document.getElementById('sourceLink');
+
+	h1$.remove();
+	img$.remove();
+
+	for (let i = 0; i < numOfContentDivs; i++) {	
+		let div$ = document.getElementById(`contentDiv${i}`);	
+		document.body.removeChild(div$);
+	}
+	
+	a$.remove();
+}
+
+/*
+function clearWebPageOfOldData() {
+	document.body.removeChild(h1);
+	document.body.removeChild(img);
+	document.body.removeChild(div); 
+	document.body.removeChild(a);
+}
+*/
 
 function loadPageContent(keyword) {
 	fetch(`https://health.gov/myhealthfinder/api/v3/topicsearch.json?keyword=${keyword}`)
@@ -119,5 +167,6 @@ loadPageContent(keyword);
 let select = document.getElementById('medKeyword');
 select.addEventListener('change', (e) => {
 	let newKeyword = e.target.value;
+	clearWebPageOfOldData();
 	loadPageContent(newKeyword);
 });


### PR DESCRIPTION
These changes make it so when a user selects a new topic, old data that was previously populating the page gets removed from it, so that new data that is more relevant to the selected topic appears at the top of the page; instead of below the content that was previously there. The user can select a new topic using the form select field, at the top of the page, which is acting as a sort of drop-down menu.